### PR TITLE
[PAN-2979] Rename from eea_ to priv_, update comments, fix tests

### DIFF
--- a/example/privacyGroupManagement/createPrivacyGroup.js
+++ b/example/privacyGroupManagement/createPrivacyGroup.js
@@ -15,7 +15,7 @@ const createPrivacyGroup = () => {
     name: "web3js-eea",
     description: "test"
   };
-  return web3.eea.createPrivacyGroup(contractOptions).then(result => {
+  return web3.priv.createPrivacyGroup(contractOptions).then(result => {
     console.log(`The privacy group created is:`, result);
     return result;
   });
@@ -32,7 +32,7 @@ const createPrivacyGroupForNode123 = () => {
     name: "web3js-eea",
     description: "test"
   };
-  return web3.eea.createPrivacyGroup(contractOptions).then(result => {
+  return web3.priv.createPrivacyGroup(contractOptions).then(result => {
     console.log(`The privacy group created is:`, result);
     return result;
   });

--- a/example/privacyGroupManagement/createPrivacyGroupNode2.js
+++ b/example/privacyGroupManagement/createPrivacyGroupNode2.js
@@ -15,7 +15,7 @@ const createPrivacyGroupForNode23 = () => {
     name: "web3js-eea",
     description: "test"
   };
-  return web3.eea.createPrivacyGroup(contractOptions).then(result => {
+  return web3.priv.createPrivacyGroup(contractOptions).then(result => {
     console.log(`The privacy group created is:`, result);
     return result;
   });

--- a/example/privacyGroupManagement/deletePrivacyGroup.js
+++ b/example/privacyGroupManagement/deletePrivacyGroup.js
@@ -13,7 +13,7 @@ const deletePrivacyGroup = givenPrivacyGroupId => {
     privacyGroupId: givenPrivacyGroupId,
     privateFrom: orion.node1.publicKey
   };
-  return web3.eea.deletePrivacyGroup(contractOptions).then(result => {
+  return web3.priv.deletePrivacyGroup(contractOptions).then(result => {
     console.log(`The privacy group deleted is:`, result);
     return result;
   });

--- a/example/privacyGroupManagement/findPrivacyGroup.js
+++ b/example/privacyGroupManagement/findPrivacyGroup.js
@@ -12,7 +12,7 @@ const findPrivacyGroup = () => {
   const contractOptions = {
     addresses: [orion.node1.publicKey, orion.node2.publicKey]
   };
-  return web3.eea.findPrivacyGroup(contractOptions).then(result => {
+  return web3.priv.findPrivacyGroup(contractOptions).then(result => {
     console.log(`The privacy groups found are:`, result);
     return result;
   });
@@ -26,7 +26,7 @@ const findPrivacyGroupForNode123 = () => {
       orion.node3.publicKey
     ]
   };
-  return web3.eea.findPrivacyGroup(contractOptions).then(result => {
+  return web3.priv.findPrivacyGroup(contractOptions).then(result => {
     console.log(`The privacy groups found are:`, result);
     return result;
   });
@@ -36,7 +36,7 @@ const findPrivacyGroupForNode23 = () => {
   const contractOptions = {
     addresses: [orion.node2.publicKey, orion.node3.publicKey]
   };
-  return web3.eea.findPrivacyGroup(contractOptions).then(result => {
+  return web3.priv.findPrivacyGroup(contractOptions).then(result => {
     console.log(`The privacy groups found are:`, result);
     return result;
   });

--- a/example/privacyGroupManagement/findPrivacyGroupNode2.js
+++ b/example/privacyGroupManagement/findPrivacyGroupNode2.js
@@ -12,7 +12,7 @@ const findPrivacyGroupForNode23 = () => {
   const contractOptions = {
     addresses: [orion.node2.publicKey, orion.node3.publicKey]
   };
-  return web3.eea.findPrivacyGroup(contractOptions).then(result => {
+  return web3.priv.findPrivacyGroup(contractOptions).then(result => {
     console.log(`The privacy groups found are:`, result);
     return result;
   });

--- a/src/custom-ethjs-util.js
+++ b/src/custom-ethjs-util.js
@@ -775,7 +775,14 @@ exports.defineProperties = function(self, fields, data) {
     }
 
     if (Array.isArray(data)) {
-      if (data.length > self._fields.length) {
+      if (data.length === 12) {
+        if (data[10].constructor === Array) {
+          data.splice(11, 0, "");
+        } else {
+          data.splice(10, 0, []);
+        }
+      }
+      if (data.length !== self._fields.length) {
         throw new Error("wrong number of fields in data");
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ function EEAClient(web3, chainId) {
 
     const payload = {
       jsonrpc: "2.0",
-      method: "eea_getTransactionCount",
+      method: "priv_getTransactionCount",
       params: [options.from, privacyGroupId],
       id: 1
     };
@@ -141,7 +141,7 @@ function EEAClient(web3, chainId) {
   const createPrivacyGroup = options => {
     const payload = {
       jsonrpc: "2.0",
-      method: "eea_createPrivacyGroup",
+      method: "priv_createPrivacyGroup",
       params: [
         options.privateFrom,
         options.name,
@@ -164,7 +164,7 @@ function EEAClient(web3, chainId) {
   const deletePrivacyGroup = options => {
     const payload = {
       jsonrpc: "2.0",
-      method: "eea_deletePrivacyGroup",
+      method: "priv_deletePrivacyGroup",
       params: [options.privateFrom, options.privacyGroupId],
       id: 1
     };
@@ -182,7 +182,7 @@ function EEAClient(web3, chainId) {
   const findPrivacyGroup = options => {
     const payload = {
       jsonrpc: "2.0",
-      method: "eea_findPrivacyGroup",
+      method: "priv_findPrivacyGroup",
       params: [options.addresses],
       id: 1
     };
@@ -193,12 +193,16 @@ function EEAClient(web3, chainId) {
   };
 
   // eslint-disable-next-line no-param-reassign
-  web3.eea = {
+  web3.priv = {
     generatePrivacyGroup,
     createPrivacyGroup,
     deletePrivacyGroup,
     findPrivacyGroup,
-    getTransactionCount,
+    getTransactionCount
+  };
+
+  // eslint-disable-next-line no-param-reassign
+  web3.eea = {
     /**
      * Send the Raw transaction to the Pantheon node
      * @param options Map to send a raw transction to pantheon
@@ -206,6 +210,7 @@ function EEAClient(web3, chainId) {
      * privateKey : Private Key used to sign transaction with
      * privateFrom : Enclave public key
      * privateFor : Enclave keys to send the transaction to
+     * privacyGroupId : Enclave id representing the reveivers of the transaction
      * nonce(Optional) : If not provided, will be calculated using `eea_getTransctionCount`
      * to : The address to send the transaction
      * data : Data to be sent in the transaction
@@ -213,10 +218,13 @@ function EEAClient(web3, chainId) {
      * @returns {Promise<AxiosResponse<any> | never>}
      */
     sendRawTransaction: options => {
+      if (options.privacyGroupId && options.privateFor) {
+        throw Error("privacyGroupId and privateFor are mutually exclusive");
+      }
       const tx = new PrivateTransaction();
       const privateKeyBuffer = Buffer.from(options.privateKey, "hex");
       const from = `0x${privateToAddress(privateKeyBuffer).toString("hex")}`;
-      return web3.eea
+      return web3.priv
         .getTransactionCount({
           from,
           privateFrom: options.privateFrom,

--- a/src/index.js
+++ b/src/index.js
@@ -210,7 +210,7 @@ function EEAClient(web3, chainId) {
      * privateKey : Private Key used to sign transaction with
      * privateFrom : Enclave public key
      * privateFor : Enclave keys to send the transaction to
-     * privacyGroupId : Enclave id representing the reveivers of the transaction
+     * privacyGroupId : Enclave id representing the receivers of the transaction
      * nonce(Optional) : If not provided, will be calculated using `eea_getTransctionCount`
      * to : The address to send the transaction
      * data : Data to be sent in the transaction

--- a/src/privateTransaction.js
+++ b/src/privateTransaction.js
@@ -48,6 +48,7 @@ const N_DIV_2 = new BN(
  * @param {Buffer} data.s EC signature parameter
  * @param {Buffer} data.privateFrom The enclave public key of the sender
  * @param {Array<Buffer>} data.privateFor The enclave public keys of the receivers
+ * @param {Buffer} data.privacyGroupId The enclave id representing the group of receivers
  * @param {Buffer} data.restriction The transaction type - "restricted" or "unrestricted"
  * @param {Number} data.chainId EIP 155 chainId - mainnet: 1, ropsten:
  * */

--- a/test/integration/errorFromNode1ForGroup23.test.js
+++ b/test/integration/errorFromNode1ForGroup23.test.js
@@ -21,8 +21,8 @@ test("[MultiNodeExample]: Can manage privacy groups", t => {
 
     const listFindFromNode1 = await findGroup.findPrivacyGroupForNode23();
 
-    // it is not list as it is an error thrown
-    st.false(Array.isArray(listFindFromNode1));
+    // node1 should not see privacyGroup23
+    st.equal(listFindFromNode1.length, 0);
 
     const listFromNode2 = await findGroupNode2.findPrivacyGroupForNode23();
 

--- a/test/unit/privacyGroupIdGeneration.test.js
+++ b/test/unit/privacyGroupIdGeneration.test.js
@@ -10,7 +10,7 @@ tape("[EEA]: Privacy Group Generation", t => {
       const input = pg.privacyGroup;
       const enclave = new Enclave({ _currentProvider: { host: "" } });
       st.equal(
-        enclave.eea.generatePrivacyGroup({ privateFrom: input }),
+        enclave.priv.generatePrivacyGroup({ privateFrom: input }),
         expected
       );
     });

--- a/test/unit/privateTransactionTest.js
+++ b/test/unit/privateTransactionTest.js
@@ -1,7 +1,6 @@
 const tape = require("tape");
 const utils = require("ethereumjs-util");
 
-const { rlp } = utils;
 const PrivateTransaction = require("../../src/privateTransaction.js");
 const txFixtures = require("./support/txs.json");
 
@@ -25,7 +24,8 @@ tape("[Transaction]: Basic functions", t => {
       for (let i = 0; i < tx.raw[10].length; i++) {
         st.equal(pt.privateFor[i].toString("base64"), tx.raw[10][i]);
       }
-      st.equal(pt.restriction.toString(), tx.raw[11]);
+      st.equal(pt.privacyGroupId.toString(), tx.raw[11]);
+      st.equal(pt.restriction.toString(), tx.raw[12]);
       transactions.push(pt);
     });
     st.end();
@@ -45,8 +45,8 @@ tape("[Transaction]: Basic functions", t => {
   });
 
   t.test("should serialize", st => {
-    transactions.forEach(tx => {
-      st.deepEqual(tx.serialize(), rlp.encode(tx.raw));
+    transactions.forEach((tx, i) => {
+      st.deepEqual(`0x${tx.serialize().toString("hex")}`, txFixtures[i].rlp);
     });
     st.end();
   });


### PR DESCRIPTION
* Moves all methods except sendRawTransaction and getTransactionReceipt from `eea` to `priv` namespace

* Updates comments to reference `privacyGroupId`

* Throws error if trying to send transaction with `eea_sendRawTransaction` with both `privateFor` and `privacyGroupId` as they should be mutually exclusive.

* Some test fixes