### PR TITLE
Updates eeajs to send an array of object object rather than an array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,13 @@ function EEAClient(web3, chainId) {
     const payload = {
       jsonrpc: "2.0",
       method: "priv_createPrivacyGroup",
-      params: [options.addresses, options.name, options.description],
+      params: [
+        {
+          addresses: options.addresses,
+          name: options.name,
+          description: options.description
+        }
+      ],
       id: 1
     };
 


### PR DESCRIPTION
More modern versions of pantheon take an array of objects instead of an array of single parameters. This should only be merged once an updated version of pantheon has been released. Integration tests currently pass when pantheon-quickstart is set to develop.