### PR TITLE
Bump version for 0.9 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-eea",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "EEA JSON-RPC API",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
This PR bumps the version in package.json to 0.9 for the new release.