### PR TITLE
Refactor library to use web3.extend()

### DIFF
--- a/example/config/httpHeaders.js
+++ b/example/config/httpHeaders.js
@@ -1,0 +1,28 @@
+const Web3 = require("web3");
+const EEAClient = require("../../src");
+
+// Define an HTTP provider, passing in the desired options:
+// from https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-http
+//  var options = {
+//    keepAlive: true,
+//    timeout: 20000, // milliseconds,
+//    headers: [{name: 'Access-Control-Allow-Origin', value: '*'},{...}],
+//    withCredentials: false,
+//    agent: {http: http.Agent(...), baseUrl: ''}
+//  };
+const providerOptions = {
+  headers: [{ name: "X-My-Custom-Header", value: "some value" }]
+};
+const httpProvider = new Web3.providers.HttpProvider(
+  "http://localhost:20000",
+  providerOptions
+);
+const web3Http = new EEAClient(new Web3(httpProvider), 2018);
+
+web3Http.eth
+  .getBlockNumber()
+  .then(num => {
+    console.log("Current block:", num);
+    return num;
+  })
+  .catch(console.error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,6 +1143,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
       "requires": {
         "follow-redirects": "1.5.10"
       }
@@ -3460,6 +3461,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -3468,6 +3470,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -3475,7 +3478,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "homepage": "https://github.com/PegaSysEng/web3js-eea#readme",
   "dependencies": {
     "async-promise-pool": "1.0.3",
-    "axios": "0.19.2",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "6.1.0",
     "lodash": "4.17.15",
@@ -58,6 +57,7 @@
     "web3": "1.2.6"
   },
   "devDependencies": {
+    "axios": "0.19.2",
     "babel-eslint": "10.0.1",
     "dotenv": "8.0.0",
     "eslint": "5.16.0",

--- a/src/privacyGroup.js
+++ b/src/privacyGroup.js
@@ -1,0 +1,38 @@
+const RLP = require("rlp");
+const _ = require("lodash");
+const { keccak256 } = require("./custom-ethjs-util");
+
+/**
+ * Generate a privacyGroupId
+ * @param options Options passed into `eea_sendRawTransaction`
+ * @returns String
+ */
+const generatePrivacyGroup = options => {
+  const participants = _.chain(options.privateFor || [])
+    .concat(options.privateFrom)
+    .uniq()
+    .map(publicKey => {
+      const buffer = Buffer.from(publicKey, "base64");
+      let result = 1;
+      buffer.forEach(value => {
+        // eslint-disable-next-line no-bitwise
+        result = (31 * result + ((value << 24) >> 24)) & 0xffffffff;
+      });
+      return { b64: publicKey, buf: buffer, hash: result };
+    })
+    .sort((a, b) => {
+      return a.hash - b.hash;
+    })
+    .map(x => {
+      return x.buf;
+    })
+    .value();
+
+  const rlp = RLP.encode(participants);
+
+  return Buffer.from(keccak256(rlp)).toString("base64");
+};
+
+module.exports = {
+  generatePrivacyGroup
+};

--- a/test/integration/support/helpers.js
+++ b/test/integration/support/helpers.js
@@ -16,8 +16,10 @@ const privacyInterfaceAbi = JSON.parse(
   fs.readFileSync(path.join(privacyArtifactDir, "PrivacyInterface.abi"))
 );
 const parseError = error => {
-  const e = JSON.parse(error);
-  return e.error;
+  const prefix = "Returned error: ";
+  const start = error.message.indexOf(prefix) + prefix.length;
+  const msg = error.message.substr(start);
+  return { message: msg };
 };
 
 module.exports = {

--- a/test/unit/privacyGroupIdGeneration.test.js
+++ b/test/unit/privacyGroupIdGeneration.test.js
@@ -1,5 +1,5 @@
 const tape = require("tape");
-const Enclave = require("../../src/index");
+const { generatePrivacyGroup } = require("../../src/privacyGroup");
 const txFixtures = require("./support/keySets.json");
 
 tape("[EEA]: Privacy Group Generation", t => {
@@ -8,11 +8,7 @@ tape("[EEA]: Privacy Group Generation", t => {
     txFixtures.forEach(pg => {
       const expected = pg.privacyGroupId;
       const input = pg.privacyGroup;
-      const enclave = new Enclave({ eth: { currentProvider: { host: "" } } });
-      st.equal(
-        enclave.priv.generatePrivacyGroup({ privateFrom: input }),
-        expected
-      );
+      st.equal(generatePrivacyGroup({ privateFrom: input }), expected);
     });
     st.end();
   });


### PR DESCRIPTION
Use `web3.extend()` to define functions that send JSON-RPC requests, so that users can pass options to the HTTP provider, or use other providers. This gives users more flexibility in configuring the provider, and takes advantage of the error-handling and validation provided by web3.

* Redefine RPC methods using `web3.extend()`
* Move axios to devDependencies
* Move `generatePrivacyGroup()` to separate module