### PR TITLE
Enable usage of WebSocket provider

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - bootnode
     ports:
       - 8545:8545/tcp
+      - 8546:8546/tcp
 
   minernode:
     image: quickstart/besu:${BESU_VERSION}

--- a/example/config/webSocket.js
+++ b/example/config/webSocket.js
@@ -3,10 +3,16 @@ const EEAClient = require("../../src");
 
 // Define a WebSocket provider, passing in the desired options:
 // See https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-ws for options
+
+// See https://besu.hyperledger.org/en/stable/HowTo/Interact/APIs/Authentication/#jwt-public-key-authentication
+// for details on authenticating with JWTs
+const JWT_TOKEN =
+  "ewogICJhbGciOiAibm9uZSIsCiAgInR5cCI6ICJKV1QiCn0.eyJpYXQiOjE1MTYyMzkwMjIsImV4cCI6NDcyOTM2MzIwMCwicGVybWlzc2lvbnMiOlsibmV0OnBlZXJDb3VudCJdfQ";
+
 const providerOptions = {
   timeout: 30000, // ms
   headers: {
-    authorization: "Basic username:password"
+    authorization: `Bearer ${JWT_TOKEN}`
   },
   reconnect: {
     auto: true,

--- a/example/config/webSocket.js
+++ b/example/config/webSocket.js
@@ -1,0 +1,36 @@
+const Web3 = require("web3");
+const EEAClient = require("../../src");
+
+// Define a WebSocket provider, passing in the desired options:
+// See https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-ws for options
+const providerOptions = {
+  timeout: 30000, // ms
+  headers: {
+    authorization: "Basic username:password"
+  },
+  reconnect: {
+    auto: true,
+    delay: 5000, // ms
+    maxAttempts: 5,
+    onTimeout: false
+  }
+};
+
+const websocketProvider = new Web3.providers.WebsocketProvider(
+  "http://localhost:8546",
+  providerOptions
+);
+
+const web3Ws = new EEAClient(new Web3(websocketProvider), 2018);
+
+web3Ws.eth
+  .getBlockNumber()
+  .then(num => {
+    console.log("Current block:", num);
+    return num;
+  })
+  .then(() => {
+    console.log("disconnecting...");
+    return web3Ws.currentProvider.disconnect();
+  })
+  .catch(console.error);

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,6 @@ function EEAClient(web3, chainId) {
   const GAS_PRICE = 0;
   const GAS_LIMIT = 3000000;
 
-  const { host } = web3.eth.currentProvider;
-
-  if (host == null) {
-    throw Error("Only supports http");
-  }
-
   /* eslint-disable no-param-reassign */
   // Initialize the extensions
   web3.priv = {};


### PR DESCRIPTION
Enable usage of a WebSocket provider (or any web3 provider). Open RPC port for WebSockets in `docker-compose` file. Add example for using WebSocket provider.