### PR TITLE
Add subscriptions to logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ atlassian-ide-plugin.xml
 # testing
 coverage/
 .nyc_output/
+
+# temporary files
+example/eventLogs/params.json

--- a/example/eventLogs/README.md
+++ b/example/eventLogs/README.md
@@ -1,0 +1,21 @@
+# Examples of getting event logs
+
+Scripts:
+- `setup.js` - create privacy group and deploy contract
+- `subscribe.js` - subscribe to new logs sent to the contract
+- `sendTransaction.js` - send a transaction to update the value in the contract
+- `getPastLogs.js` - get past logs
+
+## Usage
+Run `setup.js` to create a new privacy group and deploy an [EventEmitter](../solidity/EventEmitter/EventEmitter.sol) contract into it. The privacy group ID and the contract address will be saved in `params.json` to be used by the other scripts.
+
+Next, run `subscribe.js` to subscribe to logs for the contract. The script will print any past and incoming logs until exited.
+
+Run `sendTransaction.js` to update the value stored in the contract and emit a log. You can specify the value to store as a command line argument.
+```
+node sendTransaction.js 5
+```
+
+Each time you run the script, you should see a new log output from `subscribe.js`.
+
+Finally, run `getPastLogs.js` for all of the logs sent to the contract.

--- a/example/eventLogs/getPastLogs.js
+++ b/example/eventLogs/getPastLogs.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+const Web3 = require("web3");
+const EEAClient = require("../../src");
+
+const { besu } = require("../keys");
+
+const node = new EEAClient(new Web3(besu.node1.url), 2018);
+const params = JSON.parse(fs.readFileSync(path.join(__dirname, "params.json")));
+
+function run() {
+  const { privacyGroupId, contractAddress: address } = params;
+
+  const filter = {
+    address
+  };
+
+  return node.priv.getPastLogs(privacyGroupId, filter).then(logs => {
+    console.log("Received logs\n", logs);
+    return logs;
+  });
+}
+
+run();

--- a/example/eventLogs/sendTransaction.js
+++ b/example/eventLogs/sendTransaction.js
@@ -1,0 +1,42 @@
+const fs = require("fs");
+const path = require("path");
+const Web3 = require("web3");
+
+const { besu, orion } = require("../keys");
+const EEAClient = require("../../src");
+
+const artifact = fs.readFileSync(
+  path.join(__dirname, "../solidity/EventEmitter/EventEmitter.json")
+);
+const { abi } = JSON.parse(artifact).output;
+const params = JSON.parse(fs.readFileSync(path.join(__dirname, "params.json")));
+
+const node = new EEAClient(new Web3(besu.node1.url), 2018);
+
+async function run() {
+  const { privacyGroupId, contractAddress } = params;
+  const enclaveKey = orion.node1.publicKey;
+
+  // send a transaction
+  const args = process.argv.slice(2);
+  const value = args.shift() || 3;
+
+  const to = contractAddress;
+  const contract = new node.eth.Contract(abi);
+
+  const writeReceipt = await node.eea
+    .sendRawTransaction({
+      to,
+      data: contract.methods.store([value]).encodeABI(),
+      privateFrom: enclaveKey,
+      privacyGroupId,
+      privateKey: besu.node1.privateKey
+    })
+    .then(transactionHash => {
+      return node.priv.getTransactionReceipt(transactionHash);
+    });
+
+  console.log(writeReceipt);
+}
+
+run();

--- a/example/eventLogs/setup.js
+++ b/example/eventLogs/setup.js
@@ -1,0 +1,49 @@
+const Web3 = require("web3");
+const fs = require("fs");
+const path = require("path");
+const EEAClient = require("../../src");
+
+const { besu, orion } = require("../keys");
+
+const bytecode = fs.readFileSync(
+  path.join(__dirname, "../solidity/EventEmitter/EventEmitter.bin")
+);
+
+const provider = new Web3.providers.HttpProvider(besu.node1.url);
+const node = new EEAClient(new Web3(provider), 2018);
+
+async function run() {
+  const enclaveKey = orion.node1.publicKey;
+  const addresses = [orion.node1.publicKey, orion.node2.publicKey];
+
+  // create privacy group
+  const privacyGroupId = await node.priv.createPrivacyGroup({ addresses });
+  console.log("Created privacy group", privacyGroupId);
+
+  // deploy contract
+  const deployReceipt = await node.eea
+    .sendRawTransaction({
+      data: `0x${bytecode}`,
+      privateFrom: enclaveKey,
+      privacyGroupId,
+      privateKey: besu.node1.privateKey
+    })
+    .then(hash => {
+      return node.priv.getTransactionReceipt(hash, enclaveKey);
+    });
+
+  const { contractAddress } = deployReceipt;
+  console.log("deployed", contractAddress);
+
+  // save to file
+  const params = {
+    privacyGroupId,
+    contractAddress
+  };
+
+  fs.writeFileSync(path.join(__dirname, "params.json"), JSON.stringify(params));
+
+  console.log(params);
+}
+
+run();

--- a/example/eventLogs/subscribe.js
+++ b/example/eventLogs/subscribe.js
@@ -1,0 +1,62 @@
+const fs = require("fs");
+const path = require("path");
+const Web3 = require("web3");
+const EEAClient = require("../../src");
+
+const { besu } = require("../keys");
+
+const node = new EEAClient(new Web3(besu.node1.url), 2018);
+const params = JSON.parse(fs.readFileSync(path.join(__dirname, "params.json")));
+
+async function unsubscribe(subscription) {
+  console.log("unsubscribing", subscription.filterId);
+  await subscription
+    .unsubscribe((error, success) => {
+      if (!error) {
+        if (success) {
+          console.log("unsubscribed!");
+        } else {
+          console.log("failed to unsubscribe");
+        }
+      }
+    })
+    .catch(console.error);
+
+  process.exit(0);
+}
+
+async function run() {
+  const { privacyGroupId, contractAddress: address } = params;
+  console.log(params);
+
+  const filter = {
+    address,
+    fromBlock: 1
+  };
+
+  // Create subscription
+  return node.priv
+    .subscribe(privacyGroupId, filter, (error, result) => {
+      if (!error) {
+        console.log("installed filter", result);
+      } else {
+        console.error("Problem installing filter", error);
+        throw error;
+      }
+    })
+    .then(subscription => {
+      // Add handler for each log received
+      subscription.on("data", log => {
+        console.log("LOG =>", log);
+      });
+
+      // Unsubscribe on interrupt
+      process.on("SIGINT", () => {
+        unsubscribe(subscription);
+      });
+
+      return subscription;
+    });
+}
+
+run();

--- a/src/privateSubscription.js
+++ b/src/privateSubscription.js
@@ -1,0 +1,106 @@
+const EventEmitter = require("events");
+
+function PrivateSubscription(web3, privacyGroupId, filter) {
+  this.privacyGroupId = privacyGroupId;
+  this.filter = filter;
+
+  this.web3 = web3;
+  this.filterId = null;
+
+  this.timer = undefined;
+  this.getPast = false;
+
+  return this;
+}
+
+// get functions from EventEmitter
+PrivateSubscription.prototype = Object.create(EventEmitter.prototype);
+
+PrivateSubscription.prototype.subscribe = async function subscribe() {
+  // install filter
+  this.filterId = await this.web3.priv.createFilter(
+    this.privacyGroupId,
+    this.filter,
+    this.blockId
+  );
+
+  // If `fromBlock` is set, get previous logs when the user adds
+  // a callback for the "data" event.
+  if (this.filter.fromBlock != null) {
+    this.getPast = true;
+  }
+
+  // wait for new logs
+  await this.pollForLogs();
+
+  return this.filterId;
+};
+
+PrivateSubscription.prototype.on = async function on(eventName, callback) {
+  // Register the callback
+  EventEmitter.prototype.on.call(this, eventName, callback);
+
+  // Get past logs if necessary once the user has added a callback
+  if (this.getPast && eventName === "data") {
+    const pastLogs = await this.web3.priv.getFilterLogs(
+      this.privacyGroupId,
+      this.filterId
+    );
+    pastLogs.forEach(log => {
+      this.emit("data", log);
+    });
+  }
+};
+
+PrivateSubscription.prototype.pollForLogs = async function pollForLogs(
+  ms = 1000
+) {
+  const fetchLogs = async () => {
+    try {
+      const logs = await this.web3.priv.getFilterChanges(
+        this.privacyGroupId,
+        this.filterId
+      );
+      logs.forEach(log => {
+        this.emit("data", log);
+      });
+      // continue
+      this.timeout = setTimeout(() => {
+        this.pollForLogs(ms);
+      }, ms);
+    } catch (error) {
+      this.emit("error", error);
+    }
+  };
+
+  fetchLogs();
+};
+
+PrivateSubscription.prototype.unsubscribe = async function unsubscribe(
+  callback
+) {
+  const id = this.filterId;
+
+  return this.web3.priv
+    .uninstallFilter(this.privacyGroupId, this.filterId)
+    .then(() => {
+      if (this.timeout != null) {
+        clearTimeout(this.timeout);
+      }
+
+      this.removeAllListeners();
+      if (callback != null) {
+        callback(true);
+      }
+      return id;
+    })
+    .catch(error => {
+      if (callback != null) {
+        callback(error);
+      }
+    });
+};
+
+module.exports = {
+  PrivateSubscription
+};

--- a/test/integration/onchainPrivacy/onChainPrivacy.test.js
+++ b/test/integration/onchainPrivacy/onChainPrivacy.test.js
@@ -241,13 +241,18 @@ test("On chain privacy", async t => {
     st.test(
       "non-member node should NOT be able to write to the contract",
       async sst => {
-        const result = await writeValue(
-          node3Client,
-          orion.node3.publicKey,
-          besu.node3.privateKey,
-          3
-        );
-        sst.strictEqual(result.status, "0x0", "failed tx");
+        try {
+          await writeValue(
+            node3Client,
+            orion.node3.publicKey,
+            besu.node3.privateKey,
+            3
+          );
+          sst.fail("Non-member node was able to write to the contract");
+        } catch (error) {
+          sst.pass("Non-member could not write");
+        }
+
         sst.end();
       }
     );


### PR DESCRIPTION
Implement `web3.priv.subscribe()` to subscribe to logs with filters. This returns a `PrivateSubscription` object that can have listeners attached to it using `PrivateSubscription.on("data", callback)`, and the filter can be unsubscribed from using `PrivateSubscription.unsubscribe()`.

* Also add
  - `web3.priv.createFilter()`
  - `web3.priv.getFilterLogs()`
  - `web3.priv.getFilterChanges()`
  - `web3.priv.uninstallFilter()`
* Add example scripts for using subscriptions
