### PR TITLE
Generate privacy group id during on-chain privacy group creation

### DIFF
--- a/example/onChainPrivacy/addRemoveExample.js
+++ b/example/onChainPrivacy/addRemoveExample.js
@@ -1,4 +1,3 @@
-const crypto = require("crypto");
 const Web3 = require("web3");
 const EEAClient = require("../../src");
 
@@ -14,7 +13,6 @@ module.exports = async () => {
       participants: [orion.node1.publicKey, orion.node2.publicKey],
       enclaveKey: orion.node1.publicKey,
       privateFrom: orion.node1.publicKey,
-      privacyGroupId: crypto.randomBytes(32).toString("base64"),
       privateKey: besu.node1.privateKey
     }
   );

--- a/example/onChainPrivacy/deployContractExample.js
+++ b/example/onChainPrivacy/deployContractExample.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const path = require("path");
-const crypto = require("crypto");
 const Web3 = require("web3");
 const EEAClient = require("../../src");
 
@@ -76,14 +75,11 @@ const callGenericFunctionOnContract = (
 };
 
 module.exports = async () => {
-  const privacyGroupId = crypto.randomBytes(32).toString("base64");
-
   const privacyGroupCreationResult = await web3Node1.privx.createPrivacyGroup({
     participants: [orion.node1.publicKey, orion.node2.publicKey],
     enclaveKey: orion.node1.publicKey,
     privateFrom: orion.node1.publicKey,
-    privateKey: besu.node1.privateKey,
-    privacyGroupId
+    privateKey: besu.node1.privateKey
   });
 
   console.log(privacyGroupCreationResult);

--- a/example/onChainPrivacy/simpleExample.js
+++ b/example/onChainPrivacy/simpleExample.js
@@ -1,4 +1,3 @@
-const crypto = require("crypto");
 const Web3 = require("web3");
 const EEAClient = require("../../src");
 
@@ -13,7 +12,6 @@ module.exports = async () => {
       participants: [orion.node1.publicKey, orion.node2.publicKey],
       enclaveKey: orion.node1.publicKey,
       privateFrom: orion.node1.publicKey,
-      privacyGroupId: crypto.randomBytes(32).toString("base64"),
       privateKey: besu.node1.privateKey
     }
   );

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+const crypto = require("crypto");
+
 const { privateToAddress } = require("./custom-ethjs-util");
 const privacyProxyAbi = require("./solidity/PrivacyProxy.json").output.abi;
 const PrivateTransaction = require("./privateTransaction");
@@ -451,11 +453,15 @@ function EEAClient(web3, chainId) {
       ])
       .slice(2);
 
+    // Generate a random ID if one was not passed in
+    const privacyGroupId =
+      options.privacyGroupId || crypto.randomBytes(32).toString("base64");
+
     const functionCall = {
       to: "0x000000000000000000000000000000000000007c",
       data: functionAbi.signature + functionArgs,
       privateFrom: options.enclaveKey,
-      privacyGroupId: options.privacyGroupId,
+      privacyGroupId,
       privateKey: options.privateKey
     };
     return web3.eea.sendRawTransaction(functionCall).then(transactionHash => {


### PR DESCRIPTION
Before, when using `web3.privx.createPrivacyGroup()`, the caller was required to generate and pass in a `privacyGroupId`, which was confusing and possibly error-prone. Now, if the caller does not pass in a `privacyGroupId` in the options to `createPrivacyGroup`, it is randomly generated automatically. Addresses #98. 