### PR TITLE
Implement WebSocket pub-sub API for log subscriptions

### DIFF
--- a/example/eventLogs/README.md
+++ b/example/eventLogs/README.md
@@ -2,20 +2,21 @@
 
 Scripts:
 - `setup.js` - create privacy group and deploy contract
-- `subscribe.js` - subscribe to new logs sent to the contract
+- `subscribe.js` - subscribe to new logs sent to the contract using the HTTP polling API
+- `subscribeWebSocket.js` - subscribe to new logs sent to the contract using the WebSocket pub-sub API
 - `sendTransaction.js` - send a transaction to update the value in the contract
 - `getPastLogs.js` - get past logs
 
 ## Usage
 Run `setup.js` to create a new privacy group and deploy an [EventEmitter](../solidity/EventEmitter/EventEmitter.sol) contract into it. The privacy group ID and the contract address will be saved in `params.json` to be used by the other scripts.
 
-Next, run `subscribe.js` to subscribe to logs for the contract. The script will print any past and incoming logs until exited.
+Next, run `subscribe.js` or `subscribeWebSockets.js` to subscribe to logs for the contract. The script will print any past and incoming logs until exited.
 
 Run `sendTransaction.js` to update the value stored in the contract and emit a log. You can specify the value to store as a command line argument.
 ```
 node sendTransaction.js 5
 ```
 
-Each time you run the script, you should see a new log output from `subscribe.js`.
+Each time you run the script, you should see a new log output from `subscribe.js`/`subscribeWebSocket.js`.
 
 Finally, run `getPastLogs.js` for all of the logs sent to the contract.

--- a/example/eventLogs/setup.js
+++ b/example/eventLogs/setup.js
@@ -32,13 +32,14 @@ async function run() {
       return node.priv.getTransactionReceipt(hash, enclaveKey);
     });
 
-  const { contractAddress } = deployReceipt;
+  const { contractAddress, blockNumber } = deployReceipt;
   console.log("deployed", contractAddress);
 
   // save to file
   const params = {
     privacyGroupId,
-    contractAddress
+    contractAddress,
+    blockNumber
   };
 
   fs.writeFileSync(path.join(__dirname, "params.json"), JSON.stringify(params));

--- a/example/eventLogs/subscribe.js
+++ b/example/eventLogs/subscribe.js
@@ -10,12 +10,14 @@ const params = JSON.parse(fs.readFileSync(path.join(__dirname, "params.json")));
 
 async function run() {
   const { privacyGroupId, contractAddress: address, blockNumber } = params;
-  console.log(params);
 
   const filter = {
     address,
     fromBlock: blockNumber
   };
+
+  // Set the polling interval to something fairly high
+  node.priv.subscriptionPollingInterval = 5000;
 
   console.log("Installing filter", filter);
 

--- a/example/eventLogs/subscribe.js
+++ b/example/eventLogs/subscribe.js
@@ -9,12 +9,12 @@ const node = new EEAClient(new Web3(besu.node1.url), 2018);
 const params = JSON.parse(fs.readFileSync(path.join(__dirname, "params.json")));
 
 async function run() {
-  const { privacyGroupId, contractAddress: address } = params;
+  const { privacyGroupId, contractAddress: address, blockNumber } = params;
   console.log(params);
 
   const filter = {
     address,
-    fromBlock: 1
+    fromBlock: blockNumber
   };
 
   console.log("Installing filter", filter);

--- a/example/eventLogs/subscribeWebSockets.js
+++ b/example/eventLogs/subscribeWebSockets.js
@@ -5,16 +5,15 @@ const EEAClient = require("../../src");
 
 const { besu } = require("../keys");
 
-const node = new EEAClient(new Web3(besu.node1.url), 2018);
+const node = new EEAClient(new Web3(besu.node1.wsUrl), 2018);
 const params = JSON.parse(fs.readFileSync(path.join(__dirname, "params.json")));
 
 async function run() {
   const { privacyGroupId, contractAddress: address } = params;
-  console.log(params);
 
   const filter = {
-    address,
-    fromBlock: 1
+    address
+    // fromBlock: 1
   };
 
   console.log("Installing filter", filter);
@@ -25,31 +24,36 @@ async function run() {
       if (!error) {
         console.log("Installed filter", result);
       } else {
-        console.error("Problem installing filter", error);
+        console.error("Problem installing filter:", error);
         throw error;
       }
     })
-    .then(subscription => {
-      // Add handler for each log received
+    .then(async subscription => {
+      // Add handlers for incoming events
       subscription
         .on("data", log => {
-          console.log("LOG =>", log);
+          console.log("LOG =>", log.params);
         })
         .on("error", console.error);
 
-      // Unsubscribe on interrupt
+      // Unsubscribe and disconnect on interrupt
       process.on("SIGINT", async () => {
         console.log("unsubscribing");
         await subscription.unsubscribe((error, success) => {
           if (!error) {
             console.log("Unsubscribed:", success);
           } else {
-            console.log("Failed to unsubscribe:", error);
+            console.error("Failed to unsubscribe:", error);
           }
+
+          node.currentProvider.disconnect();
         });
       });
 
       return subscription;
+    })
+    .catch(error => {
+      console.error(error);
     });
 }
 

--- a/example/eventLogs/subscribeWebSockets.js
+++ b/example/eventLogs/subscribeWebSockets.js
@@ -9,11 +9,11 @@ const node = new EEAClient(new Web3(besu.node1.wsUrl), 2018);
 const params = JSON.parse(fs.readFileSync(path.join(__dirname, "params.json")));
 
 async function run() {
-  const { privacyGroupId, contractAddress: address } = params;
+  const { privacyGroupId, contractAddress: address, blockNumber } = params;
 
   const filter = {
-    address
-    // fromBlock: 1
+    address,
+    fromBlock: blockNumber
   };
 
   console.log("Installing filter", filter);
@@ -32,7 +32,12 @@ async function run() {
       // Add handlers for incoming events
       subscription
         .on("data", log => {
-          console.log("LOG =>", log.params);
+          if (log.result != null) {
+            // Logs from subscription are nested in `result` key
+            console.log("LOG =>", log.result);
+          } else {
+            console.log("LOG =>", log);
+          }
         })
         .on("error", console.error);
 

--- a/example/keys.js
+++ b/example/keys.js
@@ -13,16 +13,19 @@ module.exports = {
   besu: {
     node1: {
       url: "http://localhost:20000",
+      wsUrl: "ws://localhost:20001",
       privateKey:
         "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63"
     },
     node2: {
       url: "http://localhost:20002",
+      wsUrl: "ws://localhost:20003",
       privateKey:
         "c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3"
     },
     node3: {
       url: "http://localhost:20004",
+      wsUrl: "ws://localhost:20005",
       privateKey:
         "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"
     }

--- a/src/index.js
+++ b/src/index.js
@@ -350,9 +350,15 @@ function EEAClient(web3, chainId) {
 
   /**
    * Subscribe to new logs matching a filter
+   *
+   * If the provider supports subscriptions, it uses `priv_subscribe`, otherwise
+   * it uses polling and `priv_getFilterChanges` to get new logs. Returns an
+   * error to the callback if there is a problem subscribing or creating the filter.
    * @param {string} privacyGroupId
    * @param {*} filter
-   * @param {function} callback
+   * @param {function} callback returns the filter/subscription ID, or an error
+   * @return {PrivateSubscription} a subscription object that manages the
+   * lifecycle of the filter or subscription
    */
   const subscribe = async (privacyGroupId, filter, callback) => {
     const sub = new PrivateSubscription(web3, privacyGroupId, filter);

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,9 @@ function EEAClient(web3, chainId) {
 
   /* eslint-disable no-param-reassign */
   // Initialize the extensions
-  web3.priv = {};
+  web3.priv = {
+    subscriptionPollingInterval: 1000
+  };
   web3.eea = {};
   web3.privx = {};
   /* eslint-enable no-param-reassign */

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,16 @@ function EEAClient(web3, chainId) {
         call: "priv_deletePrivacyGroup",
         params: 1
       },
+      {
+        name: "subscribe",
+        call: "priv_subscribe",
+        params: 3 // type, privacyGroupId, filter
+      },
+      {
+        name: "unsubscribe",
+        call: "priv_unsubscribe",
+        params: 2 // privacyGroupId, filterId
+      },
       // privx
       {
         name: "findOnChainPrivacyGroup",

--- a/src/privateSubscription.js
+++ b/src/privateSubscription.js
@@ -57,6 +57,13 @@ PollingSubscription.prototype.subscribe = async function subscribe(
   await this.pollForLogs(privacyGroupId, this.subscription.filterId);
 };
 
+PollingSubscription.prototype.getPastLogs = async function getPastLogs(
+  privacyGroupId,
+  filterId
+) {
+  return this.web3.priv.getFilterLogs(privacyGroupId, filterId);
+};
+
 PollingSubscription.prototype.pollForLogs = async function pollForLogs(
   privacyGroupId,
   filterId
@@ -144,6 +151,11 @@ PubSubSubscription.prototype.subscribe = async function subscribe(
   );
 };
 
+PubSubSubscription.prototype.getPastLogs = async function getPastLogs() {
+  // noop - subscriptions don't get past logs
+  return Promise.resolve([]);
+};
+
 PubSubSubscription.prototype.unsubscribe = async function unsubscribe(
   privacyGroupId,
   filterId,
@@ -228,8 +240,8 @@ PrivateSubscription.prototype.on = function on(eventName, callback) {
   if (this.getPast && eventName === "data") {
     // Execute asynchronously so we can return immediately
     // eslint-disable-next-line promise/catch-or-return
-    this.web3.priv
-      .getPastLogs(this.privacyGroupId, this.filter)
+    this.manager
+      .getPastLogs(this.privacyGroupId, this.filterId)
       .then(pastLogs => {
         pastLogs.forEach(log => {
           this.emit("data", log);

--- a/src/privateSubscription.js
+++ b/src/privateSubscription.js
@@ -1,6 +1,28 @@
 const EventEmitter = require("events");
 
+const Protocol = {
+  HTTP: "HTTP",
+  WEBSOCKET: "WebSocket"
+};
+
+const Event = {
+  CONNECTED: "connected",
+  DATA: "data",
+  ERROR: "error"
+};
+
 function PrivateSubscription(web3, privacyGroupId, filter) {
+  const providerType = web3.currentProvider.constructor.name;
+  if (providerType === "HttpProvider") {
+    this.protocol = Protocol.HTTP;
+  } else if (providerType === "WebsocketProvider") {
+    this.protocol = Protocol.WEBSOCKET;
+  } else {
+    throw new Error(
+      "Current protocol does not support subscriptions. Use HTTP or WebSockets."
+    );
+  }
+
   this.privacyGroupId = privacyGroupId;
   this.filter = filter;
 
@@ -15,41 +37,69 @@ function PrivateSubscription(web3, privacyGroupId, filter) {
 
 // get functions from EventEmitter
 PrivateSubscription.prototype = Object.create(EventEmitter.prototype);
+PrivateSubscription.prototype.constructor = PrivateSubscription;
 
 PrivateSubscription.prototype.subscribe = async function subscribe() {
-  // install filter
-  this.filterId = await this.web3.priv.createFilter(
-    this.privacyGroupId,
-    this.filter,
-    this.blockId
-  );
-
   // If `fromBlock` is set, get previous logs when the user adds
   // a callback for the "data" event.
   if (this.filter.fromBlock != null) {
     this.getPast = true;
   }
 
-  // wait for new logs
-  await this.pollForLogs();
+  if (this.protocol === Protocol.HTTP) {
+    // install filter
+    this.filterId = await this.web3.priv.createFilter(
+      this.privacyGroupId,
+      this.filter,
+      this.blockId
+    );
+
+    // wait for new logs
+    await this.pollForLogs();
+  } else if (this.protocol === Protocol.WEBSOCKET) {
+    // Register provider events to forward to the caller
+    this.web3.currentProvider
+      .on("connect", () => {
+        this.emit(Event.CONNECTED);
+      })
+      .on("data", data => {
+        // Log is in `params` key of JSON-RPC response
+        this.emit(Event.DATA, data.params);
+      })
+      .on("error", e => {
+        this.emit(Event.ERROR, e);
+      });
+
+    // start subscription
+    this.filterId = await this.web3.privInternal.subscribe(
+      this.privacyGroupId,
+      "logs",
+      this.filter
+    );
+  }
 
   return this.filterId;
 };
 
-PrivateSubscription.prototype.on = async function on(eventName, callback) {
+PrivateSubscription.prototype.on = function on(eventName, callback) {
   // Register the callback
   EventEmitter.prototype.on.call(this, eventName, callback);
 
   // Get past logs if necessary once the user has added a callback
   if (this.getPast && eventName === "data") {
-    const pastLogs = await this.web3.priv.getFilterLogs(
-      this.privacyGroupId,
-      this.filterId
-    );
-    pastLogs.forEach(log => {
-      this.emit("data", log);
-    });
+    // Execute asynchronously so we can return immediately
+    // eslint-disable-next-line promise/catch-or-return
+    this.web3.priv
+      .getPastLogs(this.privacyGroupId, this.filter)
+      .then(pastLogs => {
+        pastLogs.forEach(log => {
+          this.emit("data", log);
+        });
+        return pastLogs;
+      });
   }
+
+  return this;
 };
 
 PrivateSubscription.prototype.pollForLogs = async function pollForLogs(
@@ -76,29 +126,55 @@ PrivateSubscription.prototype.pollForLogs = async function pollForLogs(
   fetchLogs();
 };
 
+PrivateSubscription.prototype.reset = function reset() {
+  if (this.timeout != null) {
+    clearTimeout(this.timeout);
+  }
+
+  this.removeAllListeners();
+};
+
 PrivateSubscription.prototype.unsubscribe = async function unsubscribe(
   callback
 ) {
   const id = this.filterId;
 
-  return this.web3.priv
-    .uninstallFilter(this.privacyGroupId, this.filterId)
-    .then(() => {
-      if (this.timeout != null) {
-        clearTimeout(this.timeout);
-      }
+  let operation = Promise.resolve();
+  if (this.protocol === Protocol.HTTP) {
+    operation = this.web3.priv
+      .uninstallFilter(this.privacyGroupId, this.filterId)
+      .then(() => {
+        this.reset();
 
-      this.removeAllListeners();
-      if (callback != null) {
-        callback(true);
-      }
-      return id;
-    })
-    .catch(error => {
-      if (callback != null) {
-        callback(error);
-      }
-    });
+        if (callback != null) {
+          callback(null, true);
+        }
+        return id;
+      })
+      .catch(error => {
+        if (callback != null) {
+          callback(error);
+        }
+        return error;
+      });
+  } else if (this.protocol === Protocol.WEBSOCKET) {
+    operation = this.web3.privInternal
+      .unsubscribe(this.privacyGroupId, this.filterId)
+      .then(result => {
+        this.reset();
+
+        callback(null, result);
+        return result;
+      })
+      .catch(error => {
+        if (callback != null) {
+          callback(error);
+        }
+        return error;
+      });
+  }
+
+  return operation;
 };
 
 module.exports = {

--- a/test/integration/getLogs.test.js
+++ b/test/integration/getLogs.test.js
@@ -33,18 +33,12 @@ test("getLogs", async t => {
 
   const contract = await factory.privateDeploy(privacyGroupId);
   const { deployReceipt } = contract;
-  const deploy1Tx = await node1Client.eth.getTransaction(
-    deployReceipt.commitmentHash
-  );
   const contract1Address = deployReceipt.contractAddress;
   console.log(deployReceipt);
 
   // send some transactions from member 1
   await contract.send("store", [1]);
   const send2Receipt = await contract.send("store", [2]);
-  const send2Tx = await node1Client.eth.getTransaction(
-    send2Receipt.commitmentHash
-  );
 
   // send some transactions from member 2
   factory.connect(
@@ -68,9 +62,6 @@ test("getLogs", async t => {
 
   // send a transaction to the second contract
   const send4Receipt = await contract2.send("store", [4]);
-  const send4Tx = await node1Client.eth.getTransaction(
-    send4Receipt.commitmentHash
-  );
 
   t.test("accessibility", async st => {
     const logCount = 4;
@@ -111,17 +102,17 @@ test("getLogs", async t => {
 
     st.test("should get logs to a given block number", async sst => {
       const logs1 = await node1Client.priv.getPastLogs(privacyGroupId, {
-        toBlock: deploy1Tx.blockNumber
+        toBlock: deployReceipt.blockNumber
       });
       sst.strictEqual(logs1.length, 0, "sees logs to deploy tx");
 
       const logs2 = await node1Client.priv.getPastLogs(privacyGroupId, {
-        toBlock: send2Tx.blockNumber
+        toBlock: send2Receipt.blockNumber
       });
       sst.strictEqual(logs2.length, 2, "sees logs to send tx 2");
 
       const logs4 = await node1Client.priv.getPastLogs(privacyGroupId, {
-        toBlock: send4Tx.blockNumber
+        toBlock: send4Receipt.blockNumber
       });
       sst.strictEqual(logs4.length, 4, "sees logs to send tx 4");
 
@@ -130,19 +121,19 @@ test("getLogs", async t => {
 
     st.test("should get logs from a given block number", async sst => {
       const logs1 = await node1Client.priv.getPastLogs(privacyGroupId, {
-        fromBlock: deploy1Tx.blockNumber
+        fromBlock: deployReceipt.blockNumber
       });
       sst.strictEqual(logs1.length, 4, "sees all logs from deploy tx");
 
       // skip 1
       const logs2 = await node1Client.priv.getPastLogs(privacyGroupId, {
-        fromBlock: send2Tx.blockNumber
+        fromBlock: send2Receipt.blockNumber
       });
       sst.strictEqual(logs2.length, 3, "sees logs from send tx 2");
 
       // skip 3
       const logs4 = await node1Client.priv.getPastLogs(privacyGroupId, {
-        fromBlock: send4Tx.blockNumber
+        fromBlock: send4Receipt.blockNumber
       });
       sst.strictEqual(logs4.length, 1, "sees logs from send tx 4");
 


### PR DESCRIPTION
Currently, `web3.priv.subscribe()` uses polling to fetch new logs. If the user is using WebSockets, detect this, and use `priv_subscribe` and `priv_unsubscribe` behind the scenes instead of polling.

Addresses #101. 

* Add priv_subscribe and priv_unsubscribe
* Update `PrivateSubscription` to handle WebSockets
* Add example of subscribing with WebSockets