### PR TITLE
fix(spdx): correct license identifier to MPL-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "orion"
   ],
   "author": "PegaSysEng <support@pegasys.tech>",
-  "license": "Apache-2.0",
+  "license": "MPL-2.0",
   "bugs": {
     "url": "https://github.com/PegaSysEng/web3js-eea/issues"
   },


### PR DESCRIPTION
Corrected "license" field from Apache-2.- to MPL-2.0 (Mozilla Public License 2.0), per repository change at commit: https://github.com/PegaSysEng/web3js-eea/commit/fc25ecd9443723f06d5c04daf80164cd401400ad
SPDX License Identifier: MPL-2.0 is the correct identifier for Mozilla Public License 2.0.
No other changes are made.